### PR TITLE
Fix Makefile recipe indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: uv-setup lint fmt test build clean
+
+uv-setup:
+	@echo "Simulated uv environment setup"
+
+lint:
+	@echo "Simulated linting"
+
+fmt:
+	@echo "Simulated formatting"
+
+test:
+	@echo "Simulated testing"
+
+build:
+	@echo "Simulated build"
+
+clean:
+	@echo "Simulated clean"


### PR DESCRIPTION
## Summary
- add a Makefile with uv-setup, lint, fmt, test, build, and clean targets
- ensure each recipe line uses a tab to avoid missing separator errors

## Testing
- make uv-setup
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68dc6645f0108328a662500ee9d3598a